### PR TITLE
Resolved peer dependencies warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "zone.js": "^0.9.1"
   },
   "peerDependencies": {
-    "@angular/core": "^8.0.3"
+    "@angular/core": ">=6.0.0"
   },
   "dependencies": {
     "intl-tel-input": "^16.0.0"


### PR DESCRIPTION
Resolve issue of warning on `npm install` on angular 6 or 7 projects